### PR TITLE
Implemented AppDispatchers interface to unify the usage of coroutines…

### DIFF
--- a/app/src/main/java/com/napptilians/doy/di/modules/AppModule.kt
+++ b/app/src/main/java/com/napptilians/doy/di/modules/AppModule.kt
@@ -1,10 +1,14 @@
 package com.napptilians.doy.di.modules
 
+import com.napptilians.commons.AppDispatchers
 import com.napptilians.commons.Constants.STRING_TO_BE_PROVIDED
 import com.napptilians.networkdatasource.di.BaseUrl
 import dagger.Module
 import dagger.Provides
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import javax.inject.Named
+import javax.inject.Singleton
 
 @Module(includes = [ApplicationDataBindsModule::class])
 object AppModule {
@@ -16,4 +20,13 @@ object AppModule {
     @Provides
     @BaseUrl
     fun provideBaseUrl(): String = "https://www.google.com"
+
+    @Provides
+    @Singleton
+    fun provideAppDispatchers(): AppDispatchers = object : AppDispatchers {
+        override val main: CoroutineDispatcher = Dispatchers.Main
+        override val io: CoroutineDispatcher = Dispatchers.IO
+        override val default: CoroutineDispatcher = Dispatchers.Default
+        override val unconfined: CoroutineDispatcher = Dispatchers.Unconfined
+    }
 }

--- a/buildSrc/src/main/java/buildSrc/Dependencies.kt
+++ b/buildSrc/src/main/java/buildSrc/Dependencies.kt
@@ -10,7 +10,7 @@ object Versions {
     const val retrofit_version = "2.7.0"
     const val okHttp_version = "3.11.0"
     const val coroutines_version = "1.3.3"
-    const val room_version = "2.2.4"
+    const val room_version = "2.2.5"
     const val junit_version = "4.12"
     const val mockk_version = "1.9.3"
     const val dagger_version = "2.25.4"

--- a/commons/src/main/java/com/napptilians/commons/AppDispatchers.kt
+++ b/commons/src/main/java/com/napptilians/commons/AppDispatchers.kt
@@ -1,0 +1,29 @@
+package com.napptilians.commons
+
+import kotlinx.coroutines.CoroutineDispatcher
+
+/**
+ * Defines the dispatchers available to use to handle the thread pools of the coroutines.
+ *
+ * @property main         Main dispatcher that uses the UI thread of Android.
+ * @property io           uses a shared pool of on-demand created threads and is designed for
+ *                        offloading of IO-intensive blocking operations.
+ * @property default      This dispatcher is used to run tasks that make intensive use of the CPU
+ *                        (App computations, algorithms, etc). It can use as many threads as
+ *                        CPU cores.
+ * @property unconfined   This dispatcher starts a coroutine in the caller thread, but only until
+ *                        the first suspension point. After suspension the coroutine resumes in
+ *                        whatever thread that is used by the corresponding suspending function,
+ *                        without confining it to any specific thread or pool. SHOULD NOT BE USED
+ *                        IN PRODUCTION CODE.
+ */
+interface AppDispatchers {
+
+    val main: CoroutineDispatcher
+
+    val io: CoroutineDispatcher
+
+    val default: CoroutineDispatcher
+
+    val unconfined: CoroutineDispatcher
+}

--- a/domain/src/main/java/com/napptilians/domain/usecases/GetMovieUseCase.kt
+++ b/domain/src/main/java/com/napptilians/domain/usecases/GetMovieUseCase.kt
@@ -1,11 +1,16 @@
 package com.napptilians.domain.usecases
 
+import com.napptilians.commons.AppDispatchers
 import com.napptilians.domain.repositories.ExampleRepository
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
-class GetMovieUseCase @Inject constructor(private val exampleRepository: ExampleRepository) {
+class GetMovieUseCase @Inject constructor(
+    appDispatchers: AppDispatchers,
+    private val exampleRepository: ExampleRepository
+) {
 
-    suspend fun execute(id: Long) = withContext(Dispatchers.IO) { exampleRepository.getMovie(id) }
+    private val ioDispatcher = appDispatchers.io
+
+    suspend fun execute(id: Long) = withContext(ioDispatcher) { exampleRepository.getMovie(id) }
 }

--- a/presentation/src/main/java/com/napptilians/features/viewmodel/MovieViewModel.kt
+++ b/presentation/src/main/java/com/napptilians/features/viewmodel/MovieViewModel.kt
@@ -1,6 +1,7 @@
 package com.napptilians.features.viewmodel
 
 import androidx.lifecycle.*
+import com.napptilians.commons.AppDispatchers
 import com.napptilians.commons.Response
 import com.napptilians.commons.error.ErrorModel
 import com.napptilians.domain.models.movie.MovieModel
@@ -16,17 +17,20 @@ import javax.inject.Inject
 
 @ExperimentalCoroutinesApi
 class MovieViewModel @Inject constructor(
+    appDispatchers: AppDispatchers,
     private val getMovieUseCase: GetMovieUseCase,
     private val getMovieUseCaseFlow: GetMovieUseCaseFlow
 ) :
     BaseViewModel<MovieModel>() {
+
+    private val ioDispatcher = appDispatchers.io
 
     private val _movieDataStream = MutableLiveData<UiStatus<MovieModel, ErrorModel>>()
     val movieDataStream: LiveData<UiStatus<MovieModel, ErrorModel>>
         get() = _movieDataStream
 
     private val _movieUiModelFlow =
-        getMovieUseCaseFlow.execute().flowOn(Dispatchers.IO)
+        getMovieUseCaseFlow.execute().flowOn(ioDispatcher)
             .asLiveData(viewModelScope.coroutineContext)
     val movieModelFlow: LiveData<Response<MovieModel, ErrorModel>>
         get() = _movieUiModelFlow


### PR DESCRIPTION
Created AppDispatchers interface in order to unify the usage of dispatchers along de app.
This interface is injected in the AppModule. 

The usage of AppDispatchers can be reviewed in MovieViewModel for example. It has to be provided via constructor as a PROPERTY and expose the desired dispatcher in a private val 
(e.g.: private val ioDispatcher = appDispatchers.io)